### PR TITLE
Distinguish tapping on Done and Cancel button in SwiftUIPhotosCropView

### DIFF
--- a/Sources/BrightroomUI/Built-in UI/PhotosCrop/SwiftUIPhotosCropView.swift
+++ b/Sources/BrightroomUI/Built-in UI/PhotosCrop/SwiftUIPhotosCropView.swift
@@ -35,21 +35,23 @@ public struct SwiftUIPhotosCropView: UIViewControllerRepresentable {
   public typealias UIViewControllerType = PhotosCropViewController
   
   private let editingStack: EditingStack
-  private let onCompleted: () -> Void
-  
-  public init(editingStack: EditingStack, onCompleted: @escaping () -> Void) {
+  private let onDone: () -> Void
+  private let onCancel: () -> Void
+
+  public init(editingStack: EditingStack, onDone: @escaping () -> Void, onCancel: @escaping () -> Void) {
     self.editingStack = editingStack
-    self.onCompleted = onCompleted
+    self.onDone = onDone
+    self.onCancel = onCancel
     editingStack.start()
   }
   
   public func makeUIViewController(context: Context) -> PhotosCropViewController {
     let cropViewController = PhotosCropViewController(editingStack: editingStack)
     cropViewController.handlers.didFinish = { _ in
-      onCompleted()
+      onDone()
     }
     cropViewController.handlers.didCancel = { _ in
-      onCompleted()
+      onCancel()
     }
     return cropViewController
   }


### PR DESCRIPTION
Currently, when using `SwiftUIPhotosCropView`, there’s no way of telling whether the user tapped Cancel button or Done button in the Crop view because the same callback function is passed to `cropViewController.handlers.didFinish` and `cropViewController.handlers.didCancel`. There's a simple and straightforward solution for that, I implemented 2 distinct functions: `onDone`, which is called when user taps the Done button (passed to `cropViewController.handlers.didFinish`), and `onCancel`, which is called when user taps the Cancel button (passed to `cropViewController.handlers.didCancel`).