### PR TITLE
Fix flipping image on preview for simulator

### DIFF
--- a/Dev/Brightroom.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/Dev/Brightroom.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -73,6 +73,15 @@
       }
     },
     {
+      "identity" : "swift-syntax",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/apple/swift-syntax.git",
+      "state" : {
+        "revision" : "6ad4ea24b01559dde0773e3d091f1b9e36175036",
+        "version" : "509.0.2"
+      }
+    },
+    {
       "identity" : "texture",
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/FluidGroup/Texture.git",
@@ -104,8 +113,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/VergeGroup/Verge.git",
       "state" : {
-        "revision" : "23b6e92fbf88e72ce0546144fbc1dc455cb5d53d",
-        "version" : "11.5.4"
+        "revision" : "a338c22b82c9a686a7131b54fa84ddad773f5c2a",
+        "version" : "12.0.0-beta.4"
       }
     }
   ],

--- a/Sources/BrightroomUI/Shared/Components/ImageViews/MetalImageView.swift
+++ b/Sources/BrightroomUI/Shared/Components/ImageViews/MetalImageView.swift
@@ -189,15 +189,25 @@ open class MetalImageView: MTKView, CIImageDisplaying, MTKViewDelegate {
     let resolvedImage: CIImage
 
     #if targetEnvironment(simulator)
+
+    if #available(iOS 17, *) {
       // Fixes geometry in Metal
-      resolvedImage =
-        image
+      resolvedImage = image
+        .transformed(by: CGAffineTransform(scaleX: scale, y: scale))
+        .transformed(by: CGAffineTransform(translationX: targetRect.origin.x, y: targetRect.origin.y))
+
+    } else {
+      // Fixes geometry in Metal
+      resolvedImage = image
         .transformed(
           by: CGAffineTransform(scaleX: 1, y: -1)
             .concatenating(.init(translationX: 0, y: image.extent.height))
             .concatenating(.init(scaleX: scale, y: scale))
             .concatenating(.init(translationX: targetRect.origin.x, y: targetRect.origin.y))
         )
+
+    }
+
 
     #else
       resolvedImage =


### PR DESCRIPTION
as iOS 17 fixed geometry issue on simulator. we don't need to use the workaround