### PR TITLE
Fix BrightroomUIPhotosCrop import typo in README example

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,7 +64,7 @@ View the [full documentation](https://www.notion.so/muukii/Brightroom-d4c59b3761
 
 ```swift
 import SwiftUI
-import BtightroomUIPhotosCrop
+import BrightroomUIPhotosCrop
 
 struct DemoCropView: View {
 


### PR DESCRIPTION
Fixes a package import typo in the cropping example in the README file.