### PR TITLE
Refactor: Migrate state management in EditingStack from Verge to swif…

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -12,18 +12,18 @@ let package = Package(
     .library(name: "BrightroomUIPhotosCrop", targets: ["BrightroomUIPhotosCrop"])
   ],
   dependencies: [
-    .package(url: "https://github.com/VergeGroup/Verge", from: "14.0.0-beta.7"),
+    .package(url: "https://github.com/VergeGroup/swift-state-graph.git", from: "0.2.0"),
     .package(url: "https://github.com/FluidGroup/TransitionPatch", from: "1.0.3"),
     .package(url: "https://github.com/FluidGroup/PrecisionLevelSlider", from: "2.1.0"),
   ],
   targets: [
     .target(
       name: "BrightroomEngine",
-      dependencies: ["Verge"]
+      dependencies: ["StateGraph"]
     ),
     .target(
       name: "BrightroomUI",
-      dependencies: ["BrightroomEngine", "Verge", "TransitionPatch"]
+      dependencies: ["BrightroomEngine", "StateGraph", "TransitionPatch"]
     ),
     .target(
       name: "BrightroomUIPhotosCrop",

--- a/Sources/BrightroomEngine/Core/EditingStack.Edit.swift
+++ b/Sources/BrightroomEngine/Core/EditingStack.Edit.swift
@@ -21,9 +21,11 @@
 
 import CoreImage
 
+// import StateGraph // Removing StateGraph import
+
 extension EditingStack {
   // TODO: Consider more effective shape
-  public struct Edit: Equatable {
+  public struct Edit: Equatable { // Remove Trackable
     func makeFilters() -> [AnyFilter] {
       return filters.makeFilters()
     }
@@ -41,12 +43,12 @@ extension EditingStack {
       self.crop = crop
     }
     
-    public struct Drawings: Equatable {
+    public struct Drawings: Equatable { // Remove Trackable
       // TODO: Remove Rect from DrawnPath
       public var blurredMaskPaths: [DrawnPath] = []
     }
 
-    public struct Filters: Equatable {
+    public struct Filters: Equatable { // Remove Trackable
 
       public var preset: FilterPreset?
       


### PR DESCRIPTION
…t-state-graph

This commit replaces the Verge library with swift-state-graph for managing the state within EditingStack.swift and its related components.

Key changes include:
- Updated Package.swift to use swift-state-graph.
- Replaced Verge.Store with @GraphStored and @GraphComputed property wrappers in EditingStack.State and its nested structs (Loading, Loaded, Edit, Edit.Filters, Edit.Drawings).
- Refactored state mutation logic from Verge's `commit` blocks to direct property assignments.
- Replaced Verge's `sinkState` and custom observation logic with `withGraphTracking` from swift-state-graph for reactive updates.
- Removed unnecessary Trackable conformance that was erroneously added.
- Cleaned up miscellaneous state access points to use the new editingState property.

Testing for this change was skipped as per your instruction due to environment issues preventing the build.