### PR TITLE
Remove unused Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,3 +1,0 @@
-trunk:
-	pod trunk push --allow-warnings PixelEngine.podspec
-	pod trunk push --allow-warnings PixelEditor.podspec


### PR DESCRIPTION
## Summary
- Removed the unused Makefile that contained outdated pod trunk push commands

## Test plan
- [x] Verified the Makefile is not referenced anywhere in the codebase
- [x] No build scripts or CI workflows depend on this file

🤖 Generated with [Claude Code](https://claude.ai/code)